### PR TITLE
add state pattern

### DIFF
--- a/uber_sante/models/cart.py
+++ b/uber_sante/models/cart.py
@@ -20,7 +20,7 @@ class Cart:
         return self.appointments
 
     def remove_appointment(self, availability_id):
-        self.cart_state.remove_appointment(availability_id)
+        return self.cart_state.remove_appointment(availability_id)
 
     def contains_annual_appointment(self):
         return type(self.cart_state) == CartWithAnnualState

--- a/uber_sante/models/cart.py
+++ b/uber_sante/models/cart.py
@@ -1,9 +1,13 @@
+from abc import ABC, abstractmethod
+
+
 class Cart:
     def __init__(self):
         self.appointments = []
+        self.cart_state = CartWithoutAnnualState(self)
 
     def add_appointment(self, appointment):
-        self.appointments.append(appointment)
+        self.cart_state.add_appointment(appointment)
 
     def get_appointment(self, availability_id):
         """ searches the list of appointment and returns the none that has the specified id"""
@@ -16,21 +20,72 @@ class Cart:
         return self.appointments
 
     def remove_appointment(self, availability_id):
-        """ searches through the list of appointments and if found it removes it and returns it"""
+        self.cart_state.remove_appointment(availability_id)
+
+    def contains_annual_appointment(self):
+        return type(self.cart_state) == CartWithAnnualState
+
+    def set_state(self, state):
+        self.cart_state = state
+
+    def get_state(self):
+        return self.cart_state
+
+
+class CartState(ABC):
+
+    def __init__(self, cart):
+        self.cart = cart
+
+    @abstractmethod
+    def add_appointment(self, appointment):
+        pass
+
+    @abstractmethod
+    def remove_appointment(self, availability_id):
+        pass
+
+
+class CartWithoutAnnualState(CartState):
+
+    def add_appointment(self, appointment):
+        """ adds an appointment, and if that appointment is of type annual, it will change the cart state"""
+        self.cart.appointments.append(appointment)
+
+        if appointment.is_annual_appointment():
+            self.cart.set_state(CartWithAnnualState(self.cart))
+
+    def remove_appointment(self, availability_id):
         index = 0
 
-        for appointment in self.appointments:
-
+        for appointment in self.cart.appointments:
             if appointment.get_availability_id() == availability_id:
-                return self.appointments.pop(index)
+                return self.cart.appointments.pop(index)
 
             index = index + 1
         return None
 
-    def contains_annual_appointment(self):
-        """ searches through the list to see if any of the appointments are annual """
-        for appointment in self.appointments:
-            if appointment.is_annual_appointment():
-                return True
 
-        return False
+class CartWithAnnualState(CartState):
+
+    def add_appointment(self, appointment):
+        if appointment.is_annual_appointment():
+            print("Cart has annual appointment already")
+            return -1
+
+        self.cart.appointments.append(appointment)
+
+    def remove_appointment(self, availability_id):
+        """removes an appointment and if that appointment was an annual appointment, change the state of the cart"""
+        index = 0
+        for appointment in self.cart.appointments:
+
+            if appointment.get_availability_id() == availability_id:
+
+                if appointment.is_annual_appointment():
+                    self.cart.set_state(CartWithoutAnnualState(self.cart))
+
+                return self.cart.appointments.pop(index)
+
+            index = index + 1
+        return None


### PR DESCRIPTION
#142

Cart now has a reference to an abstract `CartState`, which (currently) has two implementations: `CartWithAnnualState` and `CartWithoutAnnualState`. These both implement the `add_appointment()` and `remove_appointment()` methods, so that the state of the cart changes when we add or remove an annual appointment (since we can only have on annual appointment in a cart). The benefit of this is that in the future we could add new implementations, eg if we have a limit to our cart, we can have a CartIsFullState, etc.